### PR TITLE
Fix a bug on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.13"
 bytes = "1.2.1"
 clap = { version = "3.2.15", features = ["derive"] }
 chrono = "0.4"
+dunce = "1.0.2"
 humansize = "1.1.1"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4.13"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Local};
 use clap::Parser;
 use humansize::{file_size_opts, FileSize};
-use std::{fs::read_dir, fmt::{Display, Formatter}, net::{IpAddr, SocketAddr}, path::Path, sync::Arc, fs};
+use std::{fs::read_dir, fmt::{Display, Formatter}, net::{IpAddr, SocketAddr}, path::Path, sync::Arc};
 use tower::ServiceExt;
 use tower_http::{services::ServeDir, trace::TraceLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -28,7 +28,7 @@ struct Args {
 async fn main() {
     let args = Args::parse();
     let socket_address: SocketAddr = (args.host, args.http_port).into();
-    let root = fs::canonicalize(args.root).unwrap();
+    let root = dunce::canonicalize(args.root).unwrap();
 
     let config = Arc::new(Args {
         host: args.host,


### PR DESCRIPTION
`std::fs::canonicalize()` returns UNC path(e.g. `\\?\C:\hoge`) on Windows. However, what I want is a normal path(e.g. `C:\hoge`). Therefore, we change it so that we can get the normal path.